### PR TITLE
fix: ensure numeric columns are saved as Int16 in CSV

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -373,15 +373,15 @@ def transform(
             'HR_FIRST',
             'SYSBP_FIRST',
             'DIASBP_FIRST',
-            'RESPRATE_FIRST',
+            # 'RESPRATE_FIRST',
             # 'HEIGHT_FIRST',
             # 'WEIGHT_FIRST',
             # 'BMI',
-            'NTPROBNP_FIRST',
-            'CREATININE_FIRST',
-            'BUN_FIRST',
-            'POTASSIUM_FIRST',
-            'TOTAL_CHOLESTEROL_FIRST',
+            # 'NTPROBNP_FIRST',
+            # 'CREATININE_FIRST',
+            # 'BUN_FIRST',
+            # 'POTASSIUM_FIRST',
+            # 'TOTAL_CHOLESTEROL_FIRST',
             # 'LOS_ICU',
         ]
         for col in numeric_columns:
@@ -411,6 +411,13 @@ def transform(
         ]
         df = df[[col for col in columns_to_keep if col in df.columns]]
         console.print(f"  [green]>[/green] Kept {len(df.columns)} columns")
+
+        # Convert numeric columns to Int16 (nullable integer type)
+        int16_columns = ['HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']
+        for col in int16_columns:
+            if col in df.columns:
+                df[col] = df[col].round().astype('Int16')
+                console.print(f"  [green]>[/green] Converted {col} to Int16")
 
         console.print()
         final_rows, final_cols = df.shape


### PR DESCRIPTION
- Updated numeric_columns list in transform() to match exported columns
- Added explicit conversion to Int16 dtype before saving CSV
- Values are rounded and converted using pandas nullable Int16 type
- This ensures HR_FIRST, SYSBP_FIRST, DIASBP_FIRST are saved as integers

Previously, these columns were only configured for Int16 in SDV metadata but were still saved as float64 in the CSV file.