### PR TITLE
fix: use CREATE OR REPLACE MACRO for idempotency

### DIFF
--- a/queries/mimic_iii_validation.sql
+++ b/queries/mimic_iii_validation.sql
@@ -44,7 +44,7 @@
 -- - NULL values → "Missing"
 -- - Valid values → "1" to "num_bins" (as strings)
 -- - Handles edge cases: division by zero, values outside range
-CREATE MACRO bin_numeric(val, min_val, max_val, num_bins) AS
+CREATE OR REPLACE MACRO bin_numeric(val, min_val, max_val, num_bins) AS
     CASE WHEN val IS NULL THEN 'Missing'
          ELSE CAST(LEAST(GREATEST(
              FLOOR((val - min_val) / NULLIF(max_val - min_val, 0) * num_bins) + 1,


### PR DESCRIPTION
When exporting binned datasets, the macro gets executed multiple times in the same DuckDB connection. Using CREATE OR REPLACE allows the macro to be redefined without error.