### PR TITLE
feat: add AGE column with Int16 encoding to MIMIC-III dataset

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -170,7 +170,7 @@ def generate_encoding_config() -> dict:
         # 'HAS_ICUSTAY_DETAIL',
     ]
     numeric_columns = [
-        # 'AGE',
+        'AGE',
         'HR_FIRST',
         'SYSBP_FIRST',
         'DIASBP_FIRST',
@@ -207,7 +207,7 @@ def generate_encoding_config() -> dict:
         transformers[col] = {'type': 'UniformEncoder', 'params': {}}
     for col in numeric_columns:
         # Use Int16 for HR_FIRST, SYSBP_FIRST, DIASBP_FIRST
-        if col in ['HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']:
+        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']:
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -247,7 +247,7 @@ def generate_metadata() -> dict:
         # 'HAS_ICUSTAY_DETAIL',
     ]
     numeric_columns = [
-        # 'AGE',
+        'AGE',
         'HR_FIRST',
         'SYSBP_FIRST',
         'DIASBP_FIRST',
@@ -273,7 +273,7 @@ def generate_metadata() -> dict:
         columns[col] = {'sdtype': 'categorical'}
     for col in numeric_columns:
         # Use Int16 for HR_FIRST, SYSBP_FIRST, DIASBP_FIRST
-        if col in ['HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']:
+        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']:
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Int16'
@@ -395,7 +395,7 @@ def transform(
         # Keep only selected columns
         columns_to_keep = [
             'IS_READMISSION_30D',
-            # 'AGE',
+            'AGE',
             'GENDER',
             'ETHNICITY_GROUPED',
             'ADMISSION_TYPE',
@@ -413,7 +413,7 @@ def transform(
         console.print(f"  [green]>[/green] Kept {len(df.columns)} columns")
 
         # Convert numeric columns to Int16 (nullable integer type)
-        int16_columns = ['HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']
+        int16_columns = ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST']
         for col in int16_columns:
             if col in df.columns:
                 df[col] = df[col].round().astype('Int16')


### PR DESCRIPTION
Add AGE column back to the MIMIC-III ICU stay dataset with Int16 encoding, similar to HR_FIRST, SYSBP_FIRST, and DIASBP_FIRST.

Changes:
- prepare_mimic_iii_cli.py:
  * Add AGE to numeric_columns list in encoding config
  * Add AGE to Int16 encoding transformers (FloatFormatter)
  * Add AGE to metadata with Int16 computer_representation
  * Add AGE to columns_to_keep list
  * Add AGE to int16_columns for round() conversion

- queries/mimic_iii_validation.sql:
  * Add AGE min/max to num_ranges CTE
  * Add AGE binning to population_binned, training_binned, synthetic_binned
  * Include AGE_BIN in all hash calculations for factuality checks
  * Add AGE validation rule to synthetic_with_validity CTE
  * Update documentation comments to reflect AGE inclusion

AGE values are rounded using .round() before Int16 conversion, consistent with other numerical columns.