### PR TITLE
chore: temporarily comment out NTPROBNP_FIRST for experiment

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -178,7 +178,7 @@ def generate_encoding_config() -> dict:
         # 'HEIGHT_FIRST',
         # 'WEIGHT_FIRST',
         # 'BMI',
-        'NTPROBNP_FIRST',
+        # 'NTPROBNP_FIRST',
         # 'CREATININE_FIRST',
         # 'BUN_FIRST',
         # 'POTASSIUM_FIRST',
@@ -217,7 +217,7 @@ def generate_encoding_config() -> dict:
                     'learn_rounding_scheme': True
                 }
             }
-        elif col in ['RESPRATE_FIRST', 'NTPROBNP_FIRST']:
+        elif col == 'RESPRATE_FIRST':
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -265,7 +265,7 @@ def generate_metadata() -> dict:
         # 'HEIGHT_FIRST',
         # 'WEIGHT_FIRST',
         # 'BMI',
-        'NTPROBNP_FIRST',
+        # 'NTPROBNP_FIRST',
         # 'CREATININE_FIRST',
         # 'BUN_FIRST',
         # 'POTASSIUM_FIRST',
@@ -288,7 +288,7 @@ def generate_metadata() -> dict:
                 'sdtype': 'numerical',
                 'computer_representation': 'Int16'
             }
-        elif col in ['RESPRATE_FIRST', 'NTPROBNP_FIRST']:
+        elif col == 'RESPRATE_FIRST':
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Float'
@@ -392,7 +392,7 @@ def transform(
             # 'HEIGHT_FIRST',
             # 'WEIGHT_FIRST',
             # 'BMI',
-            'NTPROBNP_FIRST',
+            # 'NTPROBNP_FIRST',
             # 'CREATININE_FIRST',
             # 'BUN_FIRST',
             # 'POTASSIUM_FIRST',
@@ -418,7 +418,7 @@ def transform(
             'SYSBP_FIRST',
             'DIASBP_FIRST',
             'RESPRATE_FIRST',
-            'NTPROBNP_FIRST',
+            # 'NTPROBNP_FIRST',
             # 'CREATININE_FIRST',
             # 'BUN_FIRST',
             # 'POTASSIUM_FIRST',

--- a/queries/mimic_iii_validation.sql
+++ b/queries/mimic_iii_validation.sql
@@ -61,8 +61,7 @@ num_ranges AS (
         MIN(HR_FIRST) as hr_min, MAX(HR_FIRST) as hr_max,
         MIN(SYSBP_FIRST) as sysbp_min, MAX(SYSBP_FIRST) as sysbp_max,
         MIN(DIASBP_FIRST) as diasbp_min, MAX(DIASBP_FIRST) as diasbp_max,
-        MIN(RESPRATE_FIRST) as resprate_min, MAX(RESPRATE_FIRST) as resprate_max,
-        MIN(NTPROBNP_FIRST) as ntprobnp_min, MAX(NTPROBNP_FIRST) as ntprobnp_max
+        MIN(RESPRATE_FIRST) as resprate_min, MAX(RESPRATE_FIRST) as resprate_max
     FROM population
 ),
 
@@ -82,8 +81,7 @@ population_binned AS (
         bin_numeric(HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(NTPROBNP_FIRST, r.ntprobnp_min, r.ntprobnp_max, 20) as NTPROBNP_BIN
+        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
     FROM population, num_ranges r
 ),
 
@@ -99,8 +97,7 @@ training_binned AS (
         bin_numeric(HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(NTPROBNP_FIRST, r.ntprobnp_min, r.ntprobnp_max, 20) as NTPROBNP_BIN
+        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
     FROM training, num_ranges r
 ),
 
@@ -117,8 +114,7 @@ synthetic_binned AS (
         bin_numeric(s.HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(s.SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(s.DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(s.RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(s.NTPROBNP_FIRST, r.ntprobnp_min, r.ntprobnp_max, 20) as NTPROBNP_BIN
+        bin_numeric(s.RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
     FROM synthetic s, num_ranges r
 ),
 
@@ -129,21 +125,21 @@ synthetic_hashed AS (
     SELECT
         *,
         hash(GENDER_CAT, ETHNICITY_CAT, ADMISSION_CAT, READMISSION_CAT,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, NTPROBNP_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
     FROM synthetic_binned
 ),
 
 population_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, NTPROBNP_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
     FROM population_binned
 ),
 
 training_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, NTPROBNP_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
     FROM training_binned
 ),
 
@@ -155,7 +151,7 @@ population_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, NTPROBNP_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
           FROM population_binned)
 ),
 
@@ -164,7 +160,7 @@ training_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, NTPROBNP_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
           FROM training_binned)
 ),
 
@@ -284,7 +280,6 @@ synthetic_with_validity AS (
         CASE WHEN s.SYSBP_FIRST IS NULL OR (s.SYSBP_FIRST >= (SELECT sysbp_min FROM num_ranges) AND s.SYSBP_FIRST <= (SELECT sysbp_max FROM num_ranges)) THEN 1 ELSE 0 END as sysbp_valid,
         CASE WHEN s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)) THEN 1 ELSE 0 END as diasbp_valid,
         CASE WHEN s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)) THEN 1 ELSE 0 END as resprate_valid,
-        CASE WHEN s.NTPROBNP_FIRST IS NULL OR (s.NTPROBNP_FIRST >= (SELECT ntprobnp_min FROM num_ranges) AND s.NTPROBNP_FIRST <= (SELECT ntprobnp_max FROM num_ranges)) THEN 1 ELSE 0 END as ntprobnp_valid,
         -- Check if ALL rules pass
         CASE WHEN
             s.GENDER IN (SELECT value FROM valid_genders)
@@ -296,7 +291,6 @@ synthetic_with_validity AS (
             AND (s.SYSBP_FIRST IS NULL OR (s.SYSBP_FIRST >= (SELECT sysbp_min FROM num_ranges) AND s.SYSBP_FIRST <= (SELECT sysbp_max FROM num_ranges)))
             AND (s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)))
             AND (s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)))
-            AND (s.NTPROBNP_FIRST IS NULL OR (s.NTPROBNP_FIRST >= (SELECT ntprobnp_min FROM num_ranges) AND s.NTPROBNP_FIRST <= (SELECT ntprobnp_max FROM num_ranges)))
         THEN 1 ELSE 0 END as passes_all_rules
     FROM synthetic_hashed s
 ),


### PR DESCRIPTION
Comment out NTPROBNP_FIRST in both preparation and validation scripts:
- Python CLI: Reverted to commented state in all numeric_columns lists
- Python CLI: Reverted Float encoding config to RESPRATE_FIRST only
- SQL validation: Removed from binning, hashing, and plausibility checks

This is temporary for experimentation purposes.