### PR TITLE
feat: add CREATININE_FIRST column as float with 2 decimal precision

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -179,7 +179,7 @@ def generate_encoding_config() -> dict:
         # 'WEIGHT_FIRST',
         # 'BMI',
         # 'NTPROBNP_FIRST',
-        # 'CREATININE_FIRST',
+        'CREATININE_FIRST',
         # 'BUN_FIRST',
         # 'POTASSIUM_FIRST',
         # 'TOTAL_CHOLESTEROL_FIRST',
@@ -217,7 +217,7 @@ def generate_encoding_config() -> dict:
                     'learn_rounding_scheme': True
                 }
             }
-        elif col == 'RESPRATE_FIRST':
+        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST']:
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -266,7 +266,7 @@ def generate_metadata() -> dict:
         # 'WEIGHT_FIRST',
         # 'BMI',
         # 'NTPROBNP_FIRST',
-        # 'CREATININE_FIRST',
+        'CREATININE_FIRST',
         # 'BUN_FIRST',
         # 'POTASSIUM_FIRST',
         # 'TOTAL_CHOLESTEROL_FIRST',
@@ -288,7 +288,7 @@ def generate_metadata() -> dict:
                 'sdtype': 'numerical',
                 'computer_representation': 'Int16'
             }
-        elif col == 'RESPRATE_FIRST':
+        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST']:
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Float'
@@ -393,7 +393,7 @@ def transform(
             # 'WEIGHT_FIRST',
             # 'BMI',
             # 'NTPROBNP_FIRST',
-            # 'CREATININE_FIRST',
+            'CREATININE_FIRST',
             # 'BUN_FIRST',
             # 'POTASSIUM_FIRST',
             # 'TOTAL_CHOLESTEROL_FIRST',
@@ -419,7 +419,7 @@ def transform(
             'DIASBP_FIRST',
             'RESPRATE_FIRST',
             # 'NTPROBNP_FIRST',
-            # 'CREATININE_FIRST',
+            'CREATININE_FIRST',
             # 'BUN_FIRST',
             # 'POTASSIUM_FIRST',
             # 'TOTAL_CHOLESTEROL_FIRST',
@@ -433,6 +433,13 @@ def transform(
             if col in df.columns:
                 df[col] = df[col].round().astype('Int16')
                 console.print(f"  [green]>[/green] Converted {col} to Int16")
+
+        # Round float columns to 2 decimal places
+        float_columns = ['CREATININE_FIRST']
+        for col in float_columns:
+            if col in df.columns:
+                df[col] = df[col].round(2)
+                console.print(f"  [green]>[/green] Rounded {col} to 2 decimal places")
 
         console.print()
         final_rows, final_cols = df.shape

--- a/queries/mimic_iii_validation.sql
+++ b/queries/mimic_iii_validation.sql
@@ -61,7 +61,8 @@ num_ranges AS (
         MIN(HR_FIRST) as hr_min, MAX(HR_FIRST) as hr_max,
         MIN(SYSBP_FIRST) as sysbp_min, MAX(SYSBP_FIRST) as sysbp_max,
         MIN(DIASBP_FIRST) as diasbp_min, MAX(DIASBP_FIRST) as diasbp_max,
-        MIN(RESPRATE_FIRST) as resprate_min, MAX(RESPRATE_FIRST) as resprate_max
+        MIN(RESPRATE_FIRST) as resprate_min, MAX(RESPRATE_FIRST) as resprate_max,
+        MIN(CREATININE_FIRST) as creatinine_min, MAX(CREATININE_FIRST) as creatinine_max
     FROM population
 ),
 
@@ -81,7 +82,8 @@ population_binned AS (
         bin_numeric(HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
+        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
+        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
     FROM population, num_ranges r
 ),
 
@@ -97,7 +99,8 @@ training_binned AS (
         bin_numeric(HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
+        bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
+        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
     FROM training, num_ranges r
 ),
 
@@ -114,7 +117,8 @@ synthetic_binned AS (
         bin_numeric(s.HR_FIRST, r.hr_min, r.hr_max, 20) as HR_BIN,
         bin_numeric(s.SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(s.DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
-        bin_numeric(s.RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN
+        bin_numeric(s.RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
+        bin_numeric(s.CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
     FROM synthetic s, num_ranges r
 ),
 
@@ -125,21 +129,21 @@ synthetic_hashed AS (
     SELECT
         *,
         hash(GENDER_CAT, ETHNICITY_CAT, ADMISSION_CAT, READMISSION_CAT,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
     FROM synthetic_binned
 ),
 
 population_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
     FROM population_binned
 ),
 
 training_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
     FROM training_binned
 ),
 
@@ -151,7 +155,7 @@ population_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
           FROM population_binned)
 ),
 
@@ -160,7 +164,7 @@ training_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
           FROM training_binned)
 ),
 
@@ -280,6 +284,7 @@ synthetic_with_validity AS (
         CASE WHEN s.SYSBP_FIRST IS NULL OR (s.SYSBP_FIRST >= (SELECT sysbp_min FROM num_ranges) AND s.SYSBP_FIRST <= (SELECT sysbp_max FROM num_ranges)) THEN 1 ELSE 0 END as sysbp_valid,
         CASE WHEN s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)) THEN 1 ELSE 0 END as diasbp_valid,
         CASE WHEN s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)) THEN 1 ELSE 0 END as resprate_valid,
+        CASE WHEN s.CREATININE_FIRST IS NULL OR (s.CREATININE_FIRST >= (SELECT creatinine_min FROM num_ranges) AND s.CREATININE_FIRST <= (SELECT creatinine_max FROM num_ranges)) THEN 1 ELSE 0 END as creatinine_valid,
         -- Check if ALL rules pass
         CASE WHEN
             s.GENDER IN (SELECT value FROM valid_genders)
@@ -291,6 +296,7 @@ synthetic_with_validity AS (
             AND (s.SYSBP_FIRST IS NULL OR (s.SYSBP_FIRST >= (SELECT sysbp_min FROM num_ranges) AND s.SYSBP_FIRST <= (SELECT sysbp_max FROM num_ranges)))
             AND (s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)))
             AND (s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)))
+            AND (s.CREATININE_FIRST IS NULL OR (s.CREATININE_FIRST >= (SELECT creatinine_min FROM num_ranges) AND s.CREATININE_FIRST <= (SELECT creatinine_max FROM num_ranges)))
         THEN 1 ELSE 0 END as passes_all_rules
     FROM synthetic_hashed s
 ),


### PR DESCRIPTION
Add creatinine (CREATININE_FIRST) to MIMIC-III dataset preparation:
- Python CLI: Added to numeric columns with explicit Float encoding
- Python CLI: Added rounding logic to trim values to 2 decimal places
- SQL validation: Added to binning, hashing, and plausibility checks
- Treated as float like RESPRATE_FIRST to preserve decimal precision

Configuration:
- Encoding: FloatFormatter with computer_representation='Float'
- Metadata: sdtype='numerical' with computer_representation='Float'
- Rounding: Values rounded to 2 decimal places during transformation
- Includes enforce_min_max_values and learn_rounding_scheme params