### PR TITLE
feat: add POTASSIUM_FIRST column as float with 2 decimal precision

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -181,7 +181,7 @@ def generate_encoding_config() -> dict:
         # 'NTPROBNP_FIRST',
         'CREATININE_FIRST',
         # 'BUN_FIRST',
-        # 'POTASSIUM_FIRST',
+        'POTASSIUM_FIRST',
         # 'TOTAL_CHOLESTEROL_FIRST',
         # 'LOS_ICU',
     ]
@@ -217,7 +217,7 @@ def generate_encoding_config() -> dict:
                     'learn_rounding_scheme': True
                 }
             }
-        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST']:
+        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST', 'POTASSIUM_FIRST']:
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -268,7 +268,7 @@ def generate_metadata() -> dict:
         # 'NTPROBNP_FIRST',
         'CREATININE_FIRST',
         # 'BUN_FIRST',
-        # 'POTASSIUM_FIRST',
+        'POTASSIUM_FIRST',
         # 'TOTAL_CHOLESTEROL_FIRST',
         # 'LOS_ICU',
     ]
@@ -288,7 +288,7 @@ def generate_metadata() -> dict:
                 'sdtype': 'numerical',
                 'computer_representation': 'Int16'
             }
-        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST']:
+        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST', 'POTASSIUM_FIRST']:
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Float'
@@ -395,7 +395,7 @@ def transform(
             # 'NTPROBNP_FIRST',
             'CREATININE_FIRST',
             # 'BUN_FIRST',
-            # 'POTASSIUM_FIRST',
+            'POTASSIUM_FIRST',
             # 'TOTAL_CHOLESTEROL_FIRST',
             # 'LOS_ICU',
         ]
@@ -421,7 +421,7 @@ def transform(
             # 'NTPROBNP_FIRST',
             'CREATININE_FIRST',
             # 'BUN_FIRST',
-            # 'POTASSIUM_FIRST',
+            'POTASSIUM_FIRST',
             # 'TOTAL_CHOLESTEROL_FIRST',
         ]
         df = df[[col for col in columns_to_keep if col in df.columns]]
@@ -435,7 +435,7 @@ def transform(
                 console.print(f"  [green]>[/green] Converted {col} to Int16")
 
         # Round float columns to 2 decimal places
-        float_columns = ['CREATININE_FIRST']
+        float_columns = ['CREATININE_FIRST', 'POTASSIUM_FIRST']
         for col in float_columns:
             if col in df.columns:
                 df[col] = df[col].round(2)

--- a/queries/mimic_iii_validation.sql
+++ b/queries/mimic_iii_validation.sql
@@ -62,7 +62,8 @@ num_ranges AS (
         MIN(SYSBP_FIRST) as sysbp_min, MAX(SYSBP_FIRST) as sysbp_max,
         MIN(DIASBP_FIRST) as diasbp_min, MAX(DIASBP_FIRST) as diasbp_max,
         MIN(RESPRATE_FIRST) as resprate_min, MAX(RESPRATE_FIRST) as resprate_max,
-        MIN(CREATININE_FIRST) as creatinine_min, MAX(CREATININE_FIRST) as creatinine_max
+        MIN(CREATININE_FIRST) as creatinine_min, MAX(CREATININE_FIRST) as creatinine_max,
+        MIN(POTASSIUM_FIRST) as potassium_min, MAX(POTASSIUM_FIRST) as potassium_max
     FROM population
 ),
 
@@ -83,7 +84,8 @@ population_binned AS (
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
         bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
+        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN,
+        bin_numeric(POTASSIUM_FIRST, r.potassium_min, r.potassium_max, 20) as POTASSIUM_BIN
     FROM population, num_ranges r
 ),
 
@@ -100,7 +102,8 @@ training_binned AS (
         bin_numeric(SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
         bin_numeric(RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
+        bin_numeric(CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN,
+        bin_numeric(POTASSIUM_FIRST, r.potassium_min, r.potassium_max, 20) as POTASSIUM_BIN
     FROM training, num_ranges r
 ),
 
@@ -118,7 +121,8 @@ synthetic_binned AS (
         bin_numeric(s.SYSBP_FIRST, r.sysbp_min, r.sysbp_max, 20) as SYSBP_BIN,
         bin_numeric(s.DIASBP_FIRST, r.diasbp_min, r.diasbp_max, 20) as DIASBP_BIN,
         bin_numeric(s.RESPRATE_FIRST, r.resprate_min, r.resprate_max, 20) as RESPRATE_BIN,
-        bin_numeric(s.CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN
+        bin_numeric(s.CREATININE_FIRST, r.creatinine_min, r.creatinine_max, 20) as CREATININE_BIN,
+        bin_numeric(s.POTASSIUM_FIRST, r.potassium_min, r.potassium_max, 20) as POTASSIUM_BIN
     FROM synthetic s, num_ranges r
 ),
 
@@ -129,21 +133,21 @@ synthetic_hashed AS (
     SELECT
         *,
         hash(GENDER_CAT, ETHNICITY_CAT, ADMISSION_CAT, READMISSION_CAT,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN, POTASSIUM_BIN) as row_hash
     FROM synthetic_binned
 ),
 
 population_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN, POTASSIUM_BIN) as row_hash
     FROM population_binned
 ),
 
 training_hashes AS (
     SELECT DISTINCT
         hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN, POTASSIUM_BIN) as row_hash
     FROM training_binned
 ),
 
@@ -155,7 +159,7 @@ population_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN, POTASSIUM_BIN) as row_hash
           FROM population_binned)
 ),
 
@@ -164,7 +168,7 @@ training_stats AS (
         COUNT(*) as total,
         COUNT(DISTINCT row_hash) as unique_count
     FROM (SELECT hash(GENDER, ETHNICITY_GROUPED, ADMISSION_TYPE, IS_READMISSION_30D,
-             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN) as row_hash
+             AGE_BIN, HR_BIN, SYSBP_BIN, DIASBP_BIN, RESPRATE_BIN, CREATININE_BIN, POTASSIUM_BIN) as row_hash
           FROM training_binned)
 ),
 
@@ -285,6 +289,7 @@ synthetic_with_validity AS (
         CASE WHEN s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)) THEN 1 ELSE 0 END as diasbp_valid,
         CASE WHEN s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)) THEN 1 ELSE 0 END as resprate_valid,
         CASE WHEN s.CREATININE_FIRST IS NULL OR (s.CREATININE_FIRST >= (SELECT creatinine_min FROM num_ranges) AND s.CREATININE_FIRST <= (SELECT creatinine_max FROM num_ranges)) THEN 1 ELSE 0 END as creatinine_valid,
+        CASE WHEN s.POTASSIUM_FIRST IS NULL OR (s.POTASSIUM_FIRST >= (SELECT potassium_min FROM num_ranges) AND s.POTASSIUM_FIRST <= (SELECT potassium_max FROM num_ranges)) THEN 1 ELSE 0 END as potassium_valid,
         -- Check if ALL rules pass
         CASE WHEN
             s.GENDER IN (SELECT value FROM valid_genders)
@@ -297,6 +302,7 @@ synthetic_with_validity AS (
             AND (s.DIASBP_FIRST IS NULL OR (s.DIASBP_FIRST >= (SELECT diasbp_min FROM num_ranges) AND s.DIASBP_FIRST <= (SELECT diasbp_max FROM num_ranges)))
             AND (s.RESPRATE_FIRST IS NULL OR (s.RESPRATE_FIRST >= (SELECT resprate_min FROM num_ranges) AND s.RESPRATE_FIRST <= (SELECT resprate_max FROM num_ranges)))
             AND (s.CREATININE_FIRST IS NULL OR (s.CREATININE_FIRST >= (SELECT creatinine_min FROM num_ranges) AND s.CREATININE_FIRST <= (SELECT creatinine_max FROM num_ranges)))
+            AND (s.POTASSIUM_FIRST IS NULL OR (s.POTASSIUM_FIRST >= (SELECT potassium_min FROM num_ranges) AND s.POTASSIUM_FIRST <= (SELECT potassium_max FROM num_ranges)))
         THEN 1 ELSE 0 END as passes_all_rules
     FROM synthetic_hashed s
 ),


### PR DESCRIPTION
Add potassium (POTASSIUM_FIRST) to MIMIC-III dataset preparation:
- Python CLI: Added to numeric columns with explicit Float encoding
- Python CLI: Added to rounding logic for 2 decimal places
- SQL validation: Added to binning, hashing, and plausibility checks
- Treated as float like CREATININE_FIRST to preserve decimal precision

Configuration:
- Encoding: FloatFormatter with computer_representation='Float'
- Metadata: sdtype='numerical' with computer_representation='Float'
- Rounding: Values rounded to 2 decimal places during transformation
- Includes enforce_min_max_values and learn_rounding_scheme params