### PR TITLE
refactor: change RESPRATE_FIRST from Float to Int16

### DIFF
--- a/prepare_mimic_iii_cli.py
+++ b/prepare_mimic_iii_cli.py
@@ -207,7 +207,7 @@ def generate_encoding_config() -> dict:
         transformers[col] = {'type': 'UniformEncoder', 'params': {}}
     for col in numeric_columns:
         # Use Int16 for HR_FIRST, SYSBP_FIRST, DIASBP_FIRST
-        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'TOTAL_CHOLESTEROL_FIRST']:
+        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'RESPRATE_FIRST', 'TOTAL_CHOLESTEROL_FIRST']:
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -217,7 +217,7 @@ def generate_encoding_config() -> dict:
                     'learn_rounding_scheme': True
                 }
             }
-        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST', 'POTASSIUM_FIRST']:
+        elif col in ['CREATININE_FIRST', 'POTASSIUM_FIRST']:
             transformers[col] = {
                 'type': 'FloatFormatter',
                 'params': {
@@ -283,12 +283,12 @@ def generate_metadata() -> dict:
         columns[col] = {'sdtype': 'categorical'}
     for col in numeric_columns:
         # Use Int16 for HR_FIRST, SYSBP_FIRST, DIASBP_FIRST
-        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'TOTAL_CHOLESTEROL_FIRST']:
+        if col in ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'RESPRATE_FIRST', 'TOTAL_CHOLESTEROL_FIRST']:
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Int16'
             }
-        elif col in ['RESPRATE_FIRST', 'CREATININE_FIRST', 'POTASSIUM_FIRST']:
+        elif col in ['CREATININE_FIRST', 'POTASSIUM_FIRST']:
             columns[col] = {
                 'sdtype': 'numerical',
                 'computer_representation': 'Float'
@@ -428,7 +428,7 @@ def transform(
         console.print(f"  [green]>[/green] Kept {len(df.columns)} columns")
 
         # Convert numeric columns to Int16 (nullable integer type)
-        int16_columns = ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'TOTAL_CHOLESTEROL_FIRST']
+        int16_columns = ['AGE', 'HR_FIRST', 'SYSBP_FIRST', 'DIASBP_FIRST', 'RESPRATE_FIRST', 'TOTAL_CHOLESTEROL_FIRST']
         for col in int16_columns:
             if col in df.columns:
                 df[col] = df[col].round().astype('Int16')


### PR DESCRIPTION
Convert RESPRATE_FIRST (respiratory rate) to use Int16 representation (like AGE and TOTAL_CHOLESTEROL_FIRST) instead of Float.

Changes:
- Encoding: Changed from Float to Int16 in FloatFormatter
- Metadata: Updated computer_representation from 'Float' to 'Int16'
- Transform: Moved to int16_columns (round and cast to Int16)
- Values will now be stored as integers instead of floats

This aligns with AGE and TOTAL_CHOLESTEROL_FIRST approach and is appropriate for respiratory rate measurements which are typically reported as whole numbers (e.g., 16 breaths/min, not 16.45).