### PR TITLE
fix: filter target column from RDT encoding config

### DIFF
--- a/sdpype/core/downstream.py
+++ b/sdpype/core/downstream.py
@@ -439,6 +439,12 @@ def train_readmission_model(
         # Load encoding config
         enc_config = load_encoding_config(encoding_config)
 
+        # Filter out target column from encoding config (it's not a feature)
+        if target_column in enc_config['sdtypes']:
+            enc_config['sdtypes'] = {k: v for k, v in enc_config['sdtypes'].items() if k != target_column}
+        if target_column in enc_config['transformers']:
+            enc_config['transformers'] = {k: v for k, v in enc_config['transformers'].items() if k != target_column}
+
         # Create and fit encoder on training data
         rdt_encoder = RDTDatasetEncoder(enc_config)
         rdt_encoder.fit(X_train)


### PR DESCRIPTION
The target column should not be encoded as it's already separated from features. Filter it out from the encoding config before creating the RDT encoder to avoid validation errors.