### PR TITLE
feat: add regularization and feature sampling parameters

### DIFF
--- a/sdpype/core/downstream.py
+++ b/sdpype/core/downstream.py
@@ -92,6 +92,16 @@ class LGBMBayesianTuner:
             'n_jobs': -1
         }
 
+        # Regularization parameters (helps with overfitting)
+        params['reg_alpha'] = trial.suggest_float('reg_alpha', 0.0, 10.0)  # L1 regularization
+        params['reg_lambda'] = trial.suggest_float('reg_lambda', 0.0, 10.0)  # L2 regularization
+
+        # Feature sampling (column subsampling - helps generalization)
+        params['feature_fraction'] = trial.suggest_float('feature_fraction', 0.5, 1.0)
+
+        # Leaf constraints (prevents too-specific leaves)
+        params['min_data_in_leaf'] = trial.suggest_int('min_data_in_leaf', 10, 50)
+
         # Class imbalance handling (mutually exclusive options)
         imbalance_method = trial.suggest_categorical(
             'imbalance_method',
@@ -204,7 +214,14 @@ class LGBMBayesianTuner:
             'n_estimators': 1000,
             'random_state': self.random_state,
             'n_jobs': -1,
-            'verbosity': -1
+            'verbosity': -1,
+            # Regularization
+            'reg_alpha': self.best_params.get('reg_alpha', 0.0),
+            'reg_lambda': self.best_params.get('reg_lambda', 0.0),
+            # Feature sampling
+            'feature_fraction': self.best_params.get('feature_fraction', 1.0),
+            # Leaf constraints
+            'min_data_in_leaf': self.best_params.get('min_data_in_leaf', 20),
         }
 
         # Add class imbalance handling if selected


### PR DESCRIPTION
Add Tier 1 hyperparameters to address overfitting:

1. Regularization:
   - reg_alpha (L1): 0.0 to 10.0 - penalizes large weights
   - reg_lambda (L2): 0.0 to 10.0 - penalizes large weights squared

2. Feature Sampling:
   - feature_fraction: 0.5 to 1.0 - column subsampling per tree
   - Helps generalization, similar to Random Forest

3. Leaf Constraints:
   - min_data_in_leaf: 10 to 50 samples
   - Prevents overly specific leaf nodes

Expected impact:
- Reduce overfitting (training 0.94 → ~0.80-0.85)
- Improve generalization (validation ~0.69 → ~0.71-0.75)
- More stable and reliable test performance
- Potentially improve recall from 59% to 60-65%

These parameters are now part of the Bayesian optimization search space and will be automatically tuned.