### PR TITLE
feat: move checkpoint output folder under experiments directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ experiments/data/              # Large data files (manual transfer)
 experiments/models/            # Large model files (manual transfer)
 experiments/metrics/          # Small JSON metrics (commit these)
 experiments/configs/          # Experiment configs (commit these)
-checkpoints/
+experiments/checkpoints/
 
 # Testing
 .pytest_cache/

--- a/recursive_train.py
+++ b/recursive_train.py
@@ -541,7 +541,7 @@ def load_all_generation_results(checkpoint_dir: Path, start_gen: int, end_gen: i
 def run(
     generations: int = typer.Option(5, "--generations", "-n", help="Number of generations to run"),
     params_file: Path = typer.Option("params.yaml", "--params", "-p", help="Path to params.yaml"),
-    checkpoint_dir: Path = typer.Option("checkpoints", "--checkpoint-dir", help="Directory for checkpoints"),
+    checkpoint_dir: Path = typer.Option("experiments/checkpoints", "--checkpoint-dir", help="Directory for checkpoints"),
     resume: bool = typer.Option(False, "--resume", "-r", help="Resume from last checkpoint"),
     resume_from: Optional[str] = typer.Option(
         None,

--- a/sdpype/core/setup.py
+++ b/sdpype/core/setup.py
@@ -33,8 +33,9 @@ def create_directory_structure():
     """Create the experiments directory structure"""
     dirs = [
         "experiments/data/raw",
-        "experiments/data/processed", 
+        "experiments/data/processed",
         "experiments/data/synthetic",
+        "experiments/checkpoints",
         "experiments/models",
         "experiments/metrics",
         "pipelines"


### PR DESCRIPTION
- Change default checkpoint path from 'checkpoints/' to 'experiments/checkpoints/'
- Add 'experiments/checkpoints' to directory creation in setup.py
- Update .gitignore to reflect new checkpoint location
- Unifies all experiment outputs (data, models, metrics, checkpoints) in single folder