### PR TITLE
fix: add missing closing parenthesis in HTML generation

### DIFF
--- a/aggregate_metrics_cli.py
+++ b/aggregate_metrics_cli.py
@@ -439,7 +439,7 @@ def generate_summary_html(
         "  </div>",
         "</body>",
         "</html>",
-    ]
+    ])
 
     html_content = "\n".join(html_parts)
     output_path.write_text(html_content)


### PR DESCRIPTION
Line 442 was missing the closing parenthesis for the html_parts.extend() call. This caused a SyntaxError when trying to run the script.