### PR TITLE
fix: pass effective_config to all metric functions instead of gen_config

### DIFF
--- a/compute_metrics_cli.py
+++ b/compute_metrics_cli.py
@@ -1500,27 +1500,27 @@ def main(
 
             console.print(f"\n[bold yellow]Generation {gen_num}[/bold yellow] ({model_id})")
 
-            # Load generation config
-            gen_config = config_data if config_data else load_generation_config(exp_folder, gen_num)
+            # Use effective_config (merged user + checkpoint config) for all metrics
+            # This ensures data paths, encoding config, etc. are available
 
             # Compute metrics
             if compute_statistical:
                 results = compute_statistical_metrics_post_training(
-                    exp_folder, model_id, parsed, metadata_obj, metadata_path, gen_config, force
+                    exp_folder, model_id, parsed, metadata_obj, metadata_path, effective_config, force
                 )
                 if results:
                     save_metrics(exp_folder, model_id, "statistical_similarity", results)
 
             if compute_detection:
                 results = compute_detection_metrics_post_training(
-                    exp_folder, model_id, parsed, metadata_obj, metadata_path, gen_config, force
+                    exp_folder, model_id, parsed, metadata_obj, metadata_path, effective_config, force
                 )
                 if results:
                     save_metrics(exp_folder, model_id, "detection_evaluation", results)
 
             if compute_hallucination:
                 results = compute_hallucination_metrics_post_training(
-                    exp_folder, model_id, parsed, metadata_obj, metadata_path, gen_config, force
+                    exp_folder, model_id, parsed, metadata_obj, metadata_path, effective_config, force
                 )
                 if results:
                     save_metrics(exp_folder, model_id, "hallucination", results)


### PR DESCRIPTION
CRITICAL BUG: All metric computation functions were receiving gen_config (which is just the raw user config without the data section) instead of effective_config (which has the merged user + checkpoint config with all data paths).

This caused:
- Hallucination: population_file not found ('data' section missing)
- Detection: encoding config not found ('encoding' section missing)
- Statistical: encoding config not found ('encoding' section missing)

Changes:
- Removed gen_config creation (line 1504)
- All three metric functions now receive effective_config:
  * compute_statistical_metrics_post_training
  * compute_detection_metrics_post_training
  * compute_hallucination_metrics_post_training

This ensures all functions have access to:
- data.population_file
- data.training_file
- data.reference_file
- encoding.config_file
- evaluation metrics configuration

The debug output confirmed: config had 'data': False when it should have had all the merged data paths from checkpoint config.