### PR TITLE
fix: make privacy_evaluation stage truly optional

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -107,7 +107,7 @@ stages:
       - experiments/data/encoded/synthetic_${experiment.name}_${config_hash}_${experiment.seed}.csv
       - experiments/data/synthetic/synthetic_data_${experiment.name}_${config_hash}_${experiment.seed}_decoded.csv
     params:
-      - evaluation.privacy
+      - evaluation
       - experiment.seed
       - experiment.name
       - config_hash


### PR DESCRIPTION
Change params from 'evaluation.privacy' to 'evaluation' to allow the stage to run even when privacy section is missing from params.yaml.

Now the stage will:
- Run and skip quickly if evaluation.privacy is not in params.yaml
- Run normally if evaluation.privacy is configured
- Still track changes to evaluation section for DVC caching

This implements Option 1 (preferred): stage always available, controlled by config presence.