### PR TITLE
feat: add k-Anonymization privacy metric

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -130,3 +130,15 @@ evaluation:
 # Hallucination evaluation (DDR + Plausibility)
   hallucination:
     query_file: queries/validation.sql
+
+  # Privacy evaluation
+  privacy:
+    metrics:
+      - name: dcr_baseline_protection
+        parameters: {}
+      - name: k_anonymization
+        parameters:
+          quasi_identifiers:  # List of column names, or null to use all columns
+            # - AGE
+            # - GENDER
+            # - ETHNICITY_GROUPED

--- a/sdpype/core/metrics.py
+++ b/sdpype/core/metrics.py
@@ -216,6 +216,25 @@ AVAILABLE_METRICS = {
                 "good": "> 0.6",
                 "moderate": "> 0.4"
             }
+        },
+        "k_anonymization": {
+            "description": "k-Anonymization privacy metric comparing group sizes in quasi-identifiers between synthetic and real data",
+            "library": "synthcity",
+            "parameters": {
+                "quasi_identifiers": {
+                    "type": "list",
+                    "default": None,
+                    "description": "List of column names to use as quasi-identifiers (None = use all columns)"
+                }
+            },
+            "outputs": ["score", "k_real", "k_synthetic", "k_ratio", "distribution_real", "distribution_synthetic", "quasi_identifiers"],
+            "reference": "Synthcity library - Privacy metric measuring k-anonymity preservation in synthetic data",
+            "direction": "maximize",
+            "interpretation": {
+                "excellent": "> 1.5",
+                "good": "> 1.0",
+                "moderate": "> 0.7"
+            }
         }
     }
 }


### PR DESCRIPTION
- Add new k_anonymization to privacy category in metrics registry
- Implement KAnonymizationMetric evaluator class using Synthcity
- Use decoded data with 20-bin discretization for numerical columns
- Add metric to factory function and DECODED_PRIVACY_METRICS set
- Add Rich table display for k-anonymization results in privacy_evaluation.py
- Add display function to compute_metrics_cli.py with distribution stats
- Include k-anonymization in text report generation with privacy assessment
- Add example configuration to params.yaml (commented quasi_identifiers)
- Metric compares synthetic data k-anonymity against real data baseline
- Outputs: k_ratio (score), k_real, k_synthetic, distribution statistics
- Higher k-ratio (>1.0) indicates better privacy protection in synthetic data

Integration follows DCRBaselineProtection pattern:
- Separate privacy category for privacy-specific metrics
- Decoded data routing (group-based, needs semantic meaning)
- 20-bin discretization for numerical columns (matches hallucination)
- Optional quasi_identifiers parameter (defaults to all columns)
- Distribution stats: min, mean, median, max, std, num_unique_groups