### PR TITLE
fix: prevent silent fallback to decoded data for encoded metrics

### DIFF
--- a/sdpype/evaluation/statistical.py
+++ b/sdpype/evaluation/statistical.py
@@ -1937,9 +1937,14 @@ def evaluate_privacy_metrics(original: pd.DataFrame,
         if metric_name in ENCODED_PRIVACY_METRICS:
             # Use encoded data for distance-based privacy metrics
             if reference_data_encoded is None or synthetic_data_encoded is None:
-                print(f"⚠️  Metric {metric_name} needs encoded data but not available, using default")
-                ref_data = original
-                syn_data = synthetic
+                error_msg = f"Metric {metric_name} requires encoded data but encoded data is not available. Run encode_evaluation stage first."
+                print(f"❌ ERROR: {error_msg}")
+                results["metrics"][metric_name] = {
+                    "status": "error",
+                    "error_message": error_msg,
+                    "parameters": parameters
+                }
+                continue  # Skip this metric
             else:
                 print(f"📊 Routing {metric_name} to ENCODED data")
                 ref_data = reference_data_encoded
@@ -1947,9 +1952,14 @@ def evaluate_privacy_metrics(original: pd.DataFrame,
         elif metric_name in DECODED_PRIVACY_METRICS:
             # Use decoded data for other privacy metrics
             if reference_data_decoded is None or synthetic_data_decoded is None:
-                print(f"⚠️  Metric {metric_name} needs decoded data but not available, using default")
-                ref_data = original
-                syn_data = synthetic
+                error_msg = f"Metric {metric_name} requires decoded data but decoded data is not available."
+                print(f"❌ ERROR: {error_msg}")
+                results["metrics"][metric_name] = {
+                    "status": "error",
+                    "error_message": error_msg,
+                    "parameters": parameters
+                }
+                continue  # Skip this metric
             else:
                 print(f"📊 Routing {metric_name} to DECODED data")
                 ref_data = reference_data_decoded

--- a/sdpype/privacy_evaluation.py
+++ b/sdpype/privacy_evaluation.py
@@ -276,8 +276,22 @@ def main(cfg: DictConfig) -> None:
     # Load data based on metric requirements
     if needs_encoding:
         print(f"📊 Loading encoded data for distance-based privacy metrics...")
-        reference_encoded = pd.read_csv(encoded_reference)
-        synthetic_encoded = pd.read_csv(encoded_synthetic)
+        try:
+            if not encoded_reference.exists():
+                raise FileNotFoundError(f"Encoded reference file not found: {encoded_reference}")
+            if not encoded_synthetic.exists():
+                raise FileNotFoundError(f"Encoded synthetic file not found: {encoded_synthetic}")
+
+            reference_encoded = pd.read_csv(encoded_reference)
+            synthetic_encoded = pd.read_csv(encoded_synthetic)
+            print(f"   ✓ Loaded encoded reference: {reference_encoded.shape}")
+            print(f"   ✓ Loaded encoded synthetic: {synthetic_encoded.shape}")
+        except Exception as e:
+            print(f"❌ ERROR: Failed to load encoded data: {e}")
+            print(f"   Metrics requiring encoded data (k_anonymization, dcr_baseline_protection) will fail.")
+            print(f"   Please ensure the encode_evaluation DVC stage has been run.")
+            reference_encoded = None
+            synthetic_encoded = None
     else:
         reference_encoded = None
         synthetic_encoded = None


### PR DESCRIPTION
Fixed the "could not convert string to float: 'F'" error by adding proper validation and error handling for missing encoded data.

Root cause:
- k_anonymization is in ENCODED_PRIVACY_METRICS (requires numerical data)
- If encoded CSV files don't exist, pd.read_csv fails silently
- Code fell back to decoded data (with strings like 'F')
- Synthcity's kAnonymization received strings → error

Changes in privacy_evaluation.py:
- Check if encoded files exist before loading
- Print clear error if files missing
- Set encoded data to None if loading fails
- Inform user to run encode_evaluation stage

Changes in statistical.py evaluate_privacy_metrics:
- Stop silent fallback to wrong data format
- If encoded metric needs encoded data but it's None → return error status
- Print clear error message with instructions
- Skip metric entirely (continue loop) instead of using wrong data
- Same treatment for decoded metrics (consistency)

Now behavior:
- If encoded files missing → clear error message
- Metric status = "error" with helpful message
- No more silent type mismatches
- User knows to run: dvc repro encode_evaluation

This prevents type errors at the cost of failing fast with clear errors.