### PR TITLE
fix: add sdmetrics_quality to DECODED_METRICS in DVC pipeline

### DIFF
--- a/sdpype/evaluate.py
+++ b/sdpype/evaluate.py
@@ -163,7 +163,8 @@ def main(cfg: DictConfig) -> None:
         'semantic_structure',   # Needs original sdtypes for comparison
         'boundary_adherence',   # Needs original numeric ranges
         'category_adherence',   # Needs original categories
-        'new_row_synthesis'     # Needs to compare original rows
+        'new_row_synthesis',    # Needs to compare original rows
+        'sdmetrics_quality'     # Needs decoded data for correlation analysis
     }
 
     # Determine which data formats we need based on configured metrics


### PR DESCRIPTION
SDMetrics quality analysis requires decoded data to properly compute:
- Categorical correlations (Cramér's V)
- Mixed-type correlations (correlation ratio)
- Distribution similarity (TVComplement, KSComplement)

Without this, the DVC pipeline was passing encoded data, resulting in:
- All categorical correlations showing 1.000 (encoded as integers)
- TVComplement scores of 0.000 (encoded vs original mismatch)
- Incorrect overall quality scores

This fix ensures the DVC pipeline matches the standalone CLI behavior.