### PR TITLE
fix: add k_anonymization to DECODED_METRICS in DVC pipeline

### DIFF
--- a/sdpype/evaluate.py
+++ b/sdpype/evaluate.py
@@ -164,7 +164,8 @@ def main(cfg: DictConfig) -> None:
         'boundary_adherence',   # Needs original numeric ranges
         'category_adherence',   # Needs original categories
         'new_row_synthesis',    # Needs to compare original rows
-        'sdmetrics_quality'     # Needs decoded data for correlation analysis
+        'sdmetrics_quality',    # Needs decoded data for correlation analysis
+        'k_anonymization'       # Needs original categorical values for quasi-identifiers
     }
 
     # Determine which data formats we need based on configured metrics


### PR DESCRIPTION
K-anonymization requires decoded data to properly analyze:
- Original categorical values for quasi-identifiers
- Actual sensitive attributes
- Proper data types for privacy analysis

Without this, the DVC pipeline would pass encoded data to k_anonymization, resulting in incorrect k-anonymity measurements on integer-encoded categorical variables instead of actual category values.

This was the same issue as sdmetrics_quality - both metrics were defined in statistical.py as requiring decoded data but were missing from the DECODED_METRICS set in evaluate.py.