### PR TITLE
feat: add k-anonymity metrics and fix SDMetrics color assignment

### DIFF
--- a/aggregate_hybrid_stratified_metrics_cli.py
+++ b/aggregate_hybrid_stratified_metrics_cli.py
@@ -103,7 +103,8 @@ def load_metrics_csv(folder: Path) -> Tuple[bool, Optional[pd.DataFrame], Option
                          "alpha_delta_precision_OC", "alpha_delta_coverage_OC", "alpha_authenticity_OC",
                          "prdc_precision", "prdc_recall", "prdc_density", "prdc_coverage",
                          "detection_gmm", "detection_xgb", "detection_mlp", "detection_linear",
-                         "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall"}
+                         "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall",
+                         "k_anonymity_reference", "k_anonymity_synthetic", "k_ratio_synthetic_reference"}
         missing_cols = required_cols - set(df.columns)
 
         if missing_cols:
@@ -325,7 +326,8 @@ def create_plotly_visualization(
                    "alpha_delta_coverage_OC", "alpha_authenticity_OC", "prdc_precision",
                    "prdc_recall", "prdc_density", "prdc_coverage", "detection_gmm",
                    "detection_xgb", "detection_mlp", "detection_linear",
-                   "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall"]
+                   "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall",
+                   "k_anonymity_reference", "k_anonymity_synthetic", "k_ratio_synthetic_reference"]
 
     colors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#9467bd", "#d62728", "#17becf", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#ff9896", "#9edae5", "#c5b0d5", "#c49c94", "#f1c40f", "#16a085", "#e91e63", "#808000", "#3498db", "#e74c3c", "#9b59b6", "#1abc9c"]
     # Blue, Orange, Green, Purple, Red, Cyan, Brown, Pink, Gray, Lime, Light Red, Light Cyan, Light Purple, Light Brown, Gold, Teal, Magenta, Olive, Sky Blue, Crimson, Amethyst, Turquoise
@@ -337,6 +339,7 @@ def create_plotly_visualization(
     complexity_metrics = ["complexity_population", "complexity_training", "complexity_reference", "complexity_synthetic"]
 
     figures = []
+    color_idx = 0  # Separate counter for color assignment
 
     for metric_idx, metric in enumerate(metrics):
         # Skip individual complexity metrics - we'll create a combined graph later
@@ -368,8 +371,9 @@ def create_plotly_visualization(
         pred_lowers = means - t_crits * stds * pi_multiplier
         pred_uppers = means + t_crits * stds * pi_multiplier
 
-        color = colors[metric_idx]
-        line_color = line_colors[metric_idx]
+        color = colors[color_idx % len(colors)]
+        line_color = line_colors[color_idx % len(line_colors)]
+        color_idx += 1
 
         # Convert colors to rgba with transparency
         outer_band_color = hex_to_rgba(gray_color, alpha=0.75)  # Gray outer band
@@ -747,7 +751,8 @@ def main(
                "alpha_delta_coverage_OC", "alpha_authenticity_OC", "prdc_precision",
                "prdc_recall", "prdc_density", "prdc_coverage", "detection_gmm",
                "detection_xgb", "detection_mlp", "detection_linear",
-               "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall"]
+               "sdmetrics_column_shapes", "sdmetrics_column_pair_trends", "sdmetrics_overall",
+               "k_anonymity_reference", "k_anonymity_synthetic", "k_ratio_synthetic_reference"]
 
     with Progress() as progress:
         task = progress.add_task("[cyan]Loading and parsing folders...", total=len(folders))

--- a/batch_trace.py
+++ b/batch_trace.py
@@ -110,7 +110,7 @@ def process_folder(
         return False, {"folder": str(folder), "error": error}
 
     try:
-        # Run trace_chain
+        # Run trace_chain (reads k-anonymity from privacy_*.json if available)
         results = trace_chain(
             model_id=model_id,
             max_generations=max_generations,

--- a/trace_chain.py
+++ b/trace_chain.py
@@ -310,6 +310,30 @@ def read_metrics(model_id: str, generation: int, experiments_root: str) -> Dict:
                 metrics['complexity_ratio_vs_training'] = comparisons.get('synthetic_vs_training_ratio', 0)
                 metrics['complexity_ratio_vs_reference'] = comparisons.get('synthetic_vs_reference_ratio', 0)
 
+    # K-Anonymity metrics (from privacy metrics file)
+    privacy_file = Path(experiments_root) / "metrics" / f"privacy_{experiment_name}_{config_hash}_{seed}.json"
+
+    if privacy_file.exists():
+        with privacy_file.open() as f:
+            data = json.load(f)
+            k_anon_data = data.get('metrics', {}).get('k_anonymization', {})
+
+            if k_anon_data.get('status') == 'success':
+                k_values = k_anon_data.get('k_values', {})
+                k_ratios = k_anon_data.get('k_ratios', {})
+
+                # Store k-anonymity for reference dataset
+                if 'reference' in k_values:
+                    metrics['k_anonymity_reference'] = k_values['reference'].get('k', 0)
+
+                # Store k-anonymity for synthetic dataset
+                if 'synthetic' in k_values:
+                    metrics['k_anonymity_synthetic'] = k_values['synthetic'].get('k', 0)
+
+                # Store Synthetic / Reference ratio
+                if 'Synthetic / Reference' in k_ratios:
+                    metrics['k_ratio_synthetic_reference'] = k_ratios['Synthetic / Reference'].get('ratio', 0)
+
     return metrics
 
 


### PR DESCRIPTION
Add k-anonymity privacy metrics to the pipeline and fix IndexError in SDMetrics plot generation. K-anonymity values are now collected, aggregated, and plotted with full statistical visualization (CI/PI bands).

Changes:
1. Fix SDMetrics color assignment IndexError:
   - Use separate color_idx counter instead of metric_idx
   - Prevents index out of range when skipping complexity metrics
   - Use modulo operator for safety

2. Add k-anonymity metrics collection:
   - Read from existing privacy_*.json files (no duplicate computation)
   - Extract k_anonymity_reference, k_anonymity_synthetic, k_ratio_synthetic_reference
   - Follows same pattern as other metrics (SDMetrics, PRDC, etc.)

3. Update aggregation pipeline:
   - Add 3 k-anonymity metrics to required columns validation
   - Include in metrics list for processing
   - Automatically plot with CI/PI bands like other metrics

Files modified:
- trace_chain.py: Read k-anonymity from privacy_*.json
- aggregate_hybrid_stratified_metrics_cli.py: Add metrics to pipeline, fix color bug
- batch_trace.py: No changes needed (uses existing privacy files)

New plots (total: 25 plots):
- k_anonymity_reference: Reference dataset privacy baseline
- k_anonymity_synthetic: Synthetic dataset privacy (higher = better)
- k_ratio_synthetic_reference: Synthetic/Reference ratio (>1 = better privacy)

All plots include:
- Inner band (colored): 95% t-based confidence interval
- Outer band (gray): 95% prediction interval
- Mean line: Trajectory across generations