### PR TITLE
feat: add more columns to drop in transform command

### DIFF
--- a/prepare_mimic_iii_mini_cli.py
+++ b/prepare_mimic_iii_mini_cli.py
@@ -134,7 +134,8 @@ def transform(
 
     Drops the following columns if present:
     - ID columns: SUBJECT_ID, HADM_ID, ICUSTAY_ID
-    - Unwanted columns: IS_NEWBORN, ICD9_CHAPTER, WEIGHT, HEIGHT, INSURANCE, RELIGION_GROUP, TEMP
+    - Unwanted columns: IS_NEWBORN, ICD9_CHAPTER, WEIGHT, HEIGHT, INSURANCE, RELIGION_GROUP, TEMP,
+                        EXPIRE_FLAG, HOSPITAL_EXPIRE_FLAG, SPO2, ICUSTAY_EXPIRE, HEMOGLOBIN, ALBUMIN
     """
     if not xlsx_path.exists():
         console.print(f"[red]Error: XLSX file not found: {xlsx_path}[/red]")
@@ -155,7 +156,9 @@ def transform(
             'SUBJECT_ID', 'HADM_ID', 'ICUSTAY_ID',
             # Other unwanted columns
             'IS_NEWBORN', 'ICD9_CHAPTER', 'WEIGHT', 'HEIGHT',
-            'INSURANCE', 'RELIGION_GROUP', 'TEMP'
+            'INSURANCE', 'RELIGION_GROUP', 'TEMP',
+            'EXPIRE_FLAG', 'HOSPITAL_EXPIRE_FLAG', 'SPO2',
+            'ICUSTAY_EXPIRE', 'HEMOGLOBIN', 'ALBUMIN'
         ]
         columns_to_drop = [col for col in unwanted_columns if col in df.columns]
 


### PR DESCRIPTION
Add 6 more columns to the unwanted columns list:
- EXPIRE_FLAG
- HOSPITAL_EXPIRE_FLAG
- SPO2
- ICUSTAY_EXPIRE
- HEMOGLOBIN
- ALBUMIN

This brings the total dropped columns to 16, further refining the dataset to only essential features.