### PR TITLE
fix: use boolean sdtype and BinaryEncoder for READMIT

### DIFF
--- a/prepare_mimic_iii_mini_cli.py
+++ b/prepare_mimic_iii_mini_cli.py
@@ -37,7 +37,7 @@ def generate_encoding_config() -> dict:
         'SBP': 'numerical',
         'DBP': 'numerical',
         'RR': 'numerical',
-        'READMIT': 'categorical',  # Boolean as categorical
+        'READMIT': 'boolean',
     }
 
     transformers = {
@@ -134,7 +134,7 @@ def generate_encoding_config() -> dict:
                 'learn_rounding_scheme': True
             }
         },
-        'READMIT': {'type': 'UniformEncoder', 'params': {}},  # Boolean as categorical
+        'READMIT': {'type': 'BinaryEncoder', 'params': {}},
     }
 
     return {
@@ -159,7 +159,7 @@ def generate_metadata() -> dict:
         'SBP': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
         'DBP': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
         'RR': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
-        'READMIT': {'sdtype': 'categorical'},  # Boolean as categorical
+        'READMIT': {'sdtype': 'boolean'},
     }
 
     return {


### PR DESCRIPTION
Change READMIT from categorical to boolean in metadata and encoding:
- Metadata: sdtype 'categorical' → 'boolean' (more semantically correct)
- Encoding: UniformEncoder → BinaryEncoder (designed for binary data)

BinaryEncoder is specifically made for boolean/binary data (0/1, True/False) and is more appropriate than UniformEncoder for this use case.