### PR TITLE
fix: change missing_value_generation from empty string to None in enc…

### DIFF
--- a/prepare_mimic_iii_mini_cli.py
+++ b/prepare_mimic_iii_mini_cli.py
@@ -48,7 +48,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -59,7 +59,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int32',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -68,7 +68,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Float',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -77,7 +77,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -86,7 +86,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Float',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -95,7 +95,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -104,7 +104,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -113,7 +113,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -122,7 +122,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }
@@ -131,7 +131,7 @@ def generate_encoding_config() -> dict:
             'type': 'FloatFormatter',
             'params': {
                 'computer_representation': 'Int16',
-                'missing_value_generation': '',
+                'missing_value_generation': None,
                 'enforce_min_max_values': True,
                 'learn_rounding_scheme': True
             }


### PR DESCRIPTION
…oding config

Changed all FloatFormatter transformers in generate_encoding_config() to use None instead of '' for missing_value_generation parameter. This ensures the YAML output renders as "missing_value_generation:" (null) instead of "missing_value_generation: ''" (empty string with quotes).

Affects all numeric fields: AGE, NTproBNP, CREAT, BUN, POTASS, CHOL, HR, SBP, DBP, RR