### PR TITLE
fix: add missing BinaryEncoder import to encoding module

### DIFF
--- a/sdpype/encoding.py
+++ b/sdpype/encoding.py
@@ -35,6 +35,7 @@ from rdt.transformers import (
     UnixTimestampEncoder,
     FloatFormatter,
 )
+from rdt.transformers.boolean import BinaryEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,7 @@ TRANSFORMER_REGISTRY = {
     'FrequencyEncoder': FrequencyEncoder,
     'UnixTimestampEncoder': UnixTimestampEncoder,
     'FloatFormatter': FloatFormatter,
+    'BinaryEncoder': BinaryEncoder,
 }
 
 


### PR DESCRIPTION
Added BinaryEncoder import from rdt.transformers.boolean and registered it in TRANSFORMER_REGISTRY. This fixes the KeyError when encoding configuration uses BinaryEncoder for boolean columns like READMIT.