### PR TITLE
feat: treat READMIT as categorical instead of boolean

### DIFF
--- a/prepare_mimic_cli.py
+++ b/prepare_mimic_cli.py
@@ -302,13 +302,13 @@ def transform_expire_flag_column(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def transform_readmission_column(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform READMISSION column: rename to READMITTED, convert to boolean."""
+    """Transform READMISSION column: rename to READMITTED, treat as categorical."""
     if 'READMISSION' in df.columns:
         # Rename to READMITTED
         df = df.rename(columns={'READMISSION': 'READMITTED'})
-        # Convert to boolean (0 -> False, 1 -> True)
-        df['READMITTED'] = df['READMITTED'].astype(bool)
-        console.print(f"  ✓ Transformed READMISSION: renamed to READMITTED, converted to boolean")
+        # Convert to string for categorical treatment
+        df['READMITTED'] = df['READMITTED'].astype(str)
+        console.print(f"  ✓ Transformed READMISSION: renamed to READMITTED, converted to categorical (string)")
     else:
         console.print(f"  - READMISSION column not found")
 
@@ -559,7 +559,7 @@ def transform(
     - Transforms ETHNICITY: fills NaN with 'Missing', converts to string type
     - Transforms DIAGNOSIS: fills NaN with 'Missing', converts to string type, strips whitespace
     - Transforms EXPIRE_FLAG: renames to DECEASED, converts to boolean
-    - Transforms READMISSION: renames to READMITTED, converts to boolean
+    - Transforms READMISSION: renames to READMITTED, converts to categorical (string)
     - Transforms POTASSIUM: converts to numeric, drops rows with non-numeric text (preserves NaN)
     - Transforms Creatinine: converts to numeric, drops rows with non-numeric text (preserves NaN)
     - Transforms BLOOD_UREA_NITRO: converts to numeric, drops rows with non-numeric text (preserves NaN)

--- a/prepare_mimic_iii_mini_cli.py
+++ b/prepare_mimic_iii_mini_cli.py
@@ -39,7 +39,7 @@ def generate_encoding_config() -> dict:
         'SBP': 'numerical',
         'DBP': 'numerical',
         'RR': 'numerical',
-        'READMIT': 'boolean',
+        'READMIT': 'categorical',
     }
 
     transformers = {
@@ -136,7 +136,7 @@ def generate_encoding_config() -> dict:
                 'learn_rounding_scheme': True
             }
         },
-        'READMIT': {'type': 'BinaryEncoder', 'params': {}},
+        'READMIT': {'type': 'UniformEncoder', 'params': {}},
     }
 
     return {
@@ -161,7 +161,7 @@ def generate_metadata() -> dict:
         'SBP': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
         'DBP': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
         'RR': {'sdtype': 'numerical', 'computer_representation': 'Int16'},
-        'READMIT': {'sdtype': 'boolean'},
+        'READMIT': {'sdtype': 'categorical'},
     }
 
     return {
@@ -295,11 +295,11 @@ def apply_transformations(df: pd.DataFrame, verbose: bool = True) -> pd.DataFram
             if verbose:
                 console.print(f"  [green]>[/green] {col} → Float (2 decimals, allows NULL)")
 
-    # READMIT
+    # READMIT - treat as categorical (keep string representation)
     if 'READMIT' in df.columns:
-        df['READMIT'] = pd.to_numeric(df['READMIT'], errors='coerce').astype('Int8')
+        df['READMIT'] = df['READMIT'].astype(str)
         if verbose:
-            console.print(f"  [green]>[/green] READMIT → Int8 (0/1 as categorical boolean)")
+            console.print(f"  [green]>[/green] READMIT → String (categorical)")
 
     return df
 


### PR DESCRIPTION
Changes made across the codebase to treat READMIT/READMITTED as a categorical feature instead of boolean:

- prepare_mimic_iii_mini_cli.py:
  - Changed sdtype from 'boolean' to 'categorical'
  - Changed transformer from BinaryEncoder to UniformEncoder
  - Updated metadata generation to use categorical sdtype
  - Modified transformation logic to convert to string instead of Int8

- prepare_mimic_cli.py:
  - Updated transform_readmission_column to convert to string
  - Updated documentation to reflect categorical treatment

READMIT will now be handled consistently with other categorical features like ADMTYPE, ETHGRP, and GENDER.